### PR TITLE
remove Bad Apostrophe from installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 Installation
 ============
 
-This section gives a brief description how to install the CakeAdmin Plugin and it's requirements.
+This section gives a brief description how to install the CakeAdmin Plugin and its requirements.
 
 [doc_toc]
 


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!
